### PR TITLE
Disable workers dev url for exec and trigger

### DIFF
--- a/api/wrangler-monitor-exec.jsonc
+++ b/api/wrangler-monitor-exec.jsonc
@@ -7,6 +7,7 @@
   "compatibility_date": "2024-09-26",
   "compatibility_flags": ["nodejs_compat"],
   "minify": true,
+  "workers_dev": false,
   "observability": {
     "enabled": true
   },

--- a/api/wrangler-monitor-trigger.jsonc
+++ b/api/wrangler-monitor-trigger.jsonc
@@ -7,6 +7,7 @@
   "compatibility_date": "2024-09-26",
   "compatibility_flags": ["nodejs_compat"],
   "minify": true,
+  "workers_dev": false,
   "observability": {
     "enabled": true
   },


### PR DESCRIPTION
There's no need to expose the Exec and Trigger workers to the public since the project uses Service Bindings and RPCs to communicate. 

Disabling these URLs enhaces security