### PR TITLE
Update ui on endpoint creation

### DIFF
--- a/src/components/nav-secondary.tsx
+++ b/src/components/nav-secondary.tsx
@@ -18,6 +18,8 @@ import {
 } from "@/registry/new-york-v4/ui/sidebar"
 import { Skeleton } from "@/registry/new-york-v4/ui/skeleton"
 import { Switch } from "@/registry/new-york-v4/ui/switch"
+import { useDataTableStore } from "@/store/data-table-store"
+import { useStatsStore } from "@/store/dashboard-stats-store"
 
 export function NavSecondary({
   items,
@@ -32,7 +34,10 @@ export function NavSecondary({
 } & React.ComponentPropsWithoutRef<typeof SidebarGroup>) {
   const { resolvedTheme, setTheme } = useTheme()
   const [mounted, setMounted] = React.useState(false)
-
+  const fetchEndpointMonitors = useDataTableStore(
+    (state) => state.fetchEndpointMonitors,
+  )
+  const fetchDashboardStats = useStatsStore((state) => state.fetchDashboardStats);
   React.useEffect(() => {
     setMounted(true)
   }, [])
@@ -42,6 +47,10 @@ export function NavSecondary({
       <SidebarGroupContent>
         <SidebarMenu className="my-4">
           <AddEndpointMonitorDialog
+          onSuccess={async () => {
+            await fetchEndpointMonitors()
+            await fetchDashboardStats()
+          }}
             trigger={
               <SidebarMenuItem className="flex items-center gap-2">
                 <SidebarMenuButton

--- a/src/components/nav-secondary.tsx
+++ b/src/components/nav-secondary.tsx
@@ -18,8 +18,8 @@ import {
 } from "@/registry/new-york-v4/ui/sidebar"
 import { Skeleton } from "@/registry/new-york-v4/ui/skeleton"
 import { Switch } from "@/registry/new-york-v4/ui/switch"
-import { useDataTableStore } from "@/store/data-table-store"
 import { useStatsStore } from "@/store/dashboard-stats-store"
+import { useDataTableStore } from "@/store/data-table-store"
 
 export function NavSecondary({
   items,
@@ -37,7 +37,9 @@ export function NavSecondary({
   const fetchEndpointMonitors = useDataTableStore(
     (state) => state.fetchEndpointMonitors,
   )
-  const fetchDashboardStats = useStatsStore((state) => state.fetchDashboardStats);
+  const fetchDashboardStats = useStatsStore(
+    (state) => state.fetchDashboardStats,
+  )
   React.useEffect(() => {
     setMounted(true)
   }, [])
@@ -47,10 +49,10 @@ export function NavSecondary({
       <SidebarGroupContent>
         <SidebarMenu className="my-4">
           <AddEndpointMonitorDialog
-          onSuccess={async () => {
-            await fetchEndpointMonitors()
-            await fetchDashboardStats()
-          }}
+            onSuccess={async () => {
+              await fetchEndpointMonitors()
+              await fetchDashboardStats()
+            }}
             trigger={
               <SidebarMenuItem className="flex items-center gap-2">
                 <SidebarMenuButton

--- a/src/components/section-cards.tsx
+++ b/src/components/section-cards.tsx
@@ -25,22 +25,20 @@ import {
 import Link from "next/link"
 import { useEffect } from "react"
 
-
 export function SectionCards() {
   // Select the state directly
-  const statsStore = useStatsStore();
+  const statsStore = useStatsStore()
 
   // Destructure the needed values from the state object
-  const { stats, isLoading, error, fetchDashboardStats } = statsStore;
+  const { stats, isLoading, error, fetchDashboardStats } = statsStore
 
   // Fetch stats on component mount
   useEffect(() => {
-     fetchDashboardStats();
-     // Set up interval if needed
-     const intervalId = setInterval(fetchDashboardStats, 60 * 1000);
-     return () => clearInterval(intervalId);
-  }, [fetchDashboardStats]); // Dependency array is correct
-
+    fetchDashboardStats()
+    // Set up interval if needed
+    const intervalId = setInterval(fetchDashboardStats, 60 * 1000)
+    return () => clearInterval(intervalId)
+  }, [fetchDashboardStats]) // Dependency array is correct
 
   if (isLoading && !stats) {
     return (
@@ -110,8 +108,8 @@ export function SectionCards() {
         <CardFooter className="flex-col items-start gap-1.5 text-sm">
           <div className="line-clamp-1 flex gap-2 font-medium">
             {data.sitesWithAlerts > 0
-                ? `${data.sitesWithAlerts} site${data.sitesWithAlerts !== 1 ? "s" : ""} with active alerts`
-                : "No active alerts"}
+              ? `${data.sitesWithAlerts} site${data.sitesWithAlerts !== 1 ? "s" : ""} with active alerts`
+              : "No active alerts"}
           </div>
           <div className="text-muted-foreground">
             Endpoint Monitors requiring attention

--- a/src/store/dashboard-stats-store.ts
+++ b/src/store/dashboard-stats-store.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand"
+import { toast } from "sonner"
+import { DEFAULT_TOAST_OPTIONS } from "@/lib/toasts" // Assuming this path is correct
+
+export interface DashboardStats {
+ totalEndpointMonitors: number
+  sitesWithAlerts: number
+  highestResponseTime: number
+  highestResponseTimeWebsiteId: string | null
+  uptimePercentage: number
+
+
+}
+
+interface StatsState {
+  // Data
+  stats: DashboardStats | null
+  isLoading: boolean
+  error: string | null
+
+  // Actions
+  fetchDashboardStats: () => Promise<void>
+}
+
+export const useStatsStore = create<StatsState>((set, get) => ({
+  // Initial state
+  stats: null,
+  isLoading: true,
+  error: null,
+
+  fetchDashboardStats: async () => {
+    set({ isLoading: true, error: null })
+
+    try {
+      const response = await fetch("/api/endpoint-monitors/stats")
+      if (!response.ok) {
+        throw new Error("Failed to fetch dashboard statistics")
+      }
+      const data = (await response.json()) as DashboardStats
+      set({
+        stats: data,
+        isLoading: false,
+        error: null,
+      })
+    } catch (error) {
+      console.error("Error fetching dashboard stats:", error)
+
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "An unknown error occurred while fetching stats"
+
+      set({
+        isLoading: false,
+        error: errorMessage,
+        stats: null,
+      })
+
+      toast.error("Failed to load dashboard statistics", {
+        ...DEFAULT_TOAST_OPTIONS,
+      })
+    }
+  },
+
+}))
+
+// Optional: Trigger initial fetch when the store module is loaded
+// This can be useful if you want stats available immediately without
+// waiting for a component to mount and call fetchDashboardStats.
+// However, it might fetch even if the stats aren't needed yet.
+// Consider if fetching within a component's useEffect is better for your case.
+// useStatsStore.getState().fetchDashboardStats();

--- a/src/store/dashboard-stats-store.ts
+++ b/src/store/dashboard-stats-store.ts
@@ -1,15 +1,13 @@
-import { create } from "zustand"
-import { toast } from "sonner"
 import { DEFAULT_TOAST_OPTIONS } from "@/lib/toasts" // Assuming this path is correct
+import { toast } from "sonner"
+import { create } from "zustand"
 
 export interface DashboardStats {
- totalEndpointMonitors: number
+  totalEndpointMonitors: number
   sitesWithAlerts: number
   highestResponseTime: number
   highestResponseTimeWebsiteId: string | null
   uptimePercentage: number
-
-
 }
 
 interface StatsState {
@@ -22,7 +20,7 @@ interface StatsState {
   fetchDashboardStats: () => Promise<void>
 }
 
-export const useStatsStore = create<StatsState>((set, get) => ({
+export const useStatsStore = create<StatsState>((set, _get) => ({
   // Initial state
   stats: null,
   isLoading: true,
@@ -61,12 +59,4 @@ export const useStatsStore = create<StatsState>((set, get) => ({
       })
     }
   },
-
 }))
-
-// Optional: Trigger initial fetch when the store module is loaded
-// This can be useful if you want stats available immediately without
-// waiting for a component to mount and call fetchDashboardStats.
-// However, it might fetch even if the stats aren't needed yet.
-// Consider if fetching within a component's useEffect is better for your case.
-// useStatsStore.getState().fetchDashboardStats();


### PR DESCRIPTION
## Significant changes:
  - I moved the logic for fetching dashboard stats into its own store, so it's easily accessible from other components. I needed it in nav-secondary.tsx. 